### PR TITLE
Add GitHub Workflow for Continuous Integration of Pull Requests

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: sudo apt-get install g++ cmake libgsl-dev     
+      run: sudo apt-get install g++ cmake libgsl-dev ninja-build  
     - name: Configure
-      run: mkdir build && cd build && cmake ..
+      run: mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
     - name: Build
       run: cmake --build build
     - name: Test

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,20 @@
+name: Continuous
+
+on:
+  pull_request:
+    branches: 
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: sudo apt-get install g++ cmake libgsl-dev     
+    - name: Configure
+      run: mkdir build && cd build && cmake ..
+    - name: Build
+      run: cmake --build build
+    - name: Test
+      run: cd build && ctest

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -6,10 +6,10 @@ on:
       - develop
 
 jobs:
-  build:
+  build-ubuntu18:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get install g++ cmake libgsl-dev ninja-build  
     - name: Configure
@@ -18,3 +18,15 @@ jobs:
       run: cmake --build build
     - name: Test
       run: cd build && ctest
+  build-macos-catalina:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: brew install cmake gsl ninja  
+      - name: Configure
+        run: mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: cd build && ctest


### PR DESCRIPTION
This adds a basic configure/build/test workflow for `BxDecay0` using [GitHub Actions](https://help.github.com/en/actions). It means that every time a pull request is made, GitHub will configure, build and test the code proposed in the Pull Request. This makes it a lot easier for people to propose changes and for them to be testing quickly.

At present, only two platforms are targeted, Ubuntu 18.04 (the primary dev platform) and macOS Catalina. More can be added if needed.

It's likely this PR *won't* itself trigger the CI to start as I'm not a member of it. I trialled on the SuperNEMO deployment fork here:

https://github.com/SuperNEMO-DBD/bxdecay0/pull/1

and the outputs can be seen under the "checks" at the bottom, or through https://github.com/SuperNEMO-DBD/bxdecay0/actions