### PR TITLE
Update CI Configuration

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,17 +1,23 @@
 name: Continuous
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     branches: 
       - develop
 
 jobs:
-  build-ubuntu18:
-    runs-on: ubuntu-latest
+  build-ubuntu:
+    strategy:
+      matrix:
+        ubuntu: [ubuntu-latest, ubuntu-20.04]
+    runs-on: ${{ matrix.ubuntu }}
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get install g++ cmake libgsl-dev ninja-build  
+      run: sudo apt-get install g++ cmake libgsl-dev ninja-build
     - name: Configure
       run: mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
     - name: Build
@@ -23,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: brew install cmake gsl ninja  
+        run: brew install cmake gsl ninja
       - name: Configure
         run: mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ set(BxDecay0_HEADERS
   bxdecay0/funbeta_1fu.h
   bxdecay0/funbeta1.h
   bxdecay0/funbeta2.h
-  bxdecay0/fe1_mods.h  
+  bxdecay0/fe1_mods.h
   bxdecay0/fe2_mods.h
   bxdecay0/fe12_mods.h
   bxdecay0/nucltransK.h
@@ -448,9 +448,7 @@ if (BXDECAY0_WITH_DBD_GA)
     INSTALL_DIR "${PROJECT_SOURCE_DIR}/resources/data"
     CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-    -DBXDECAY0DATA_WITH_DBD_GA=ON 
-    BUILD_COMMAND   make 
-    INSTALL_COMMAND make install
+    -DBXDECAY0DATA_WITH_DBD_GA=ON
     )
 endif()
 
@@ -487,9 +485,9 @@ if(BUILD_TESTING)
     message(STATUS "Appending DBD gA test...")
     list(APPEND BxDecay0_TESTS bxdecay0/testing/test_dbd_gA.cxx)
   endif()
-    
+
   set(_bxdecay0_TEST_ENVIRONMENT "BXDECAY0_RESOURCE_DIR=${PROJECT_SOURCE_DIR}/resources")
-  
+
   foreach(_testsource ${BxDecay0_TESTS})
    get_filename_component(_testname "${_testsource}" NAME_WE)
     set(_testname "bxdecay0-${_testname}")
@@ -554,7 +552,7 @@ configure_package_config_file(cmake/BxDecay0Config.cmake.in
 # Install Tree
 # targets...
 install(EXPORT BxDecay0Targets
-  NAMESPACE 
+  NAMESPACE
   DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/BxDecay0
   )
 set(BxDecay0_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")


### PR DESCRIPTION
Two small updates to the CI configuration which should make things more stable:

- Test direct pushes to `develop` branch. Ensures tests run even if changes haven't been made through PRs.
- Add Ubuntu 20.04 to platforms tested. This is in preview in GitHub runners, but should be supported.