### PR TITLE
Fix bugs in CMake and bxdecay0-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(BxDecay0 SHARED ${BxDecay0_HEADERS} ${BxDecay0_SOURCES})
 target_compile_definitions(BxDecay0 PRIVATE ENABLE_BINRELOC)
+# Ensure clients are aware of the minimum C++ standard we were compiled with
+target_compile_features(BxDecay0 PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 target_include_directories(BxDecay0 PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -509,6 +511,7 @@ endif()
 #-----------------------------------------------------------------------
 # Configure/Install support files
 # bxdecay0-config program
+file(RELATIVE_PATH BxDecay0_BINDIR_TO_PREFIX "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_PREFIX}")
 configure_file(bxdecay0-config.in
   ${PROJECT_BINARY_DIR}/bxdecay0-config
   @ONLY)
@@ -542,7 +545,7 @@ write_basic_package_version_file(
 # Build tree
 # targets...
 export(EXPORT BxDecay0Targets
-  NAMESPACE BxDecay0
+  NAMESPACE BxDecay0::
   FILE "${PROJECT_BINARY_DIR}/BxDecay0Targets.cmake"
   )
 # config file...
@@ -558,7 +561,7 @@ configure_package_config_file(cmake/BxDecay0Config.cmake.in
 # Install Tree
 # targets...
 install(EXPORT BxDecay0Targets
-  NAMESPACE
+  NAMESPACE BxDecay0::
   DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/BxDecay0
   )
 set(BxDecay0_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/bxdecay0-config.in
+++ b/bxdecay0-config.in
@@ -27,19 +27,64 @@
 # wrapper/launcher  scripts for a batch system on a computing farm).
 
 APPNAME="bxdecay0-config"
-prefix_dir="@CMAKE_INSTALL_PREFIX@"
-if [ -n "${BXDECAY0_PREFIX_DIR}" ]; then
-    echo >&2 "[log] Overriding BxDecay0 prefix dir from env 'BXDECAY0_PREFIX_DIR'..."
-    if [ ! -d "${BXDECAY0_PREFIX_DIR}" ]; then
-	echo >&2 "[error] Overridden BxDecay0 prefix dir '${BXDECAY0_PREFIX_DIR}' does not exist!"
-	exit 0
-    fi
-    prefix_dir="${BXDECAY0_PREFIX_DIR}"
+
+# Self-locate ourselves, allowing for symlinks
+#-----------------------------------------------------------------------
+# Determine location of this script.
+# NB, we don't always use the result of this calculation, but it does not
+# hurt to do it. Only possible error is if too long a chain of symbolic
+# links are used to point to the physical script.
+#
+# Resolve symbolic links to script - we should end up with a physical file
+script="$0"
+calldir=`pwd`
+loopcount=""
+
+while [ "x`readlink $script`" != "x" ] ; do
+  preloc=`dirname $script`
+  script=`readlink $script`
+
+  if [ ${script##/} = ${script##~} ] ; then
+    # The symbolic link was relative...
+    script="$preloc/$script"
+  fi
+  loopcount="l$loopcount"
+
+  if [ ${#loopcount} -gt 10 ] ; then
+    echo "error: more than 10 symbolic links to ${APPNAME} traversed."
+    exit 1
+  fi
+done
+
+# If we still have a relative path, then it must be relative to the
+# calling dir. NB we don't attempt to resolve directory symbolic
+# links or remove '.' or '..'
+if [ ${script##/} = ${script##~} ] ; then
+  script="$calldir/$script"
 fi
+
+#-----------------------------------------------------------------------
+# Finally, grab the directory in which the script is located,
+# using a helper function to resolve any intermediate ".."
+get_abs_filename() {
+  # $1 : relative filename
+  filename=$1
+  parentdir=$(dirname "${filename}")
+
+  if [ -d "${filename}" ]; then
+    echo "$(cd "${filename}" && pwd)"
+  elif [ -d "${parentdir}" ]; then
+    echo "$(cd "${parentdir}" && pwd)/$(basename "${filename}")"
+  fi
+}
+
+bin_dir="$(dirname $(get_abs_filename $script))"
+prefix_dir="$(get_abs_filename "${bin_dir}/@BxDecay0_BINDIR_TO_PREFIX@")"
+
 version_str="@BxDecay0_VERSION@"
 orig_version_str="@BxDecay0_DECAY0_VERSION@"
 lib_dir="${prefix_dir}/@CMAKE_INSTALL_LIBDIR@"
-bin_dir="${prefix_dir}/@CMAKE_INSTALL_BINDIR@"
+cmake_dir="${prefix_dir}/@CMAKE_INSTALL_CMAKEDIR@/BxDecay0"
 inc_dir="${prefix_dir}/@CMAKE_INSTALL_INCLUDEDIR@"
 data_dir="${prefix_dir}/@CMAKE_INSTALL_DATADIR@/@BxDecay0_TAG@"
 example_dir="${data_dir}/examples"
@@ -52,8 +97,7 @@ if [ -n "${BXDECAY0_RESOURCE_DIR}" ]; then
     fi
     resource_dir="${BXDECAY0_RESOURCE_DIR}"
 fi
-# cmake_dir="${prefix_dir}/@CMAKE_INSTALL_CMAKEDIR@/@BxDecay0_TAG@"
-cmake_dir="${prefix_dir}/@CMAKE_INSTALL_CMAKEDIR@/BxDecay0"
+
 
 function print_usage()
 {

--- a/cmake/BxDecay0Config.cmake.in
+++ b/cmake/BxDecay0Config.cmake.in
@@ -18,11 +18,7 @@
 #----------------------------------------------------------------------
 
 set(BxDecay0_VERSION @BxDecay0_VERSION@)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(BxDecay0_CXX_STANDARD @CMAKE_CXX_STANDARD@)
 
 @PACKAGE_INIT@
 
@@ -44,7 +40,6 @@ if(NOT BxDecay0_TARGETS_LOADED)
   set(BxDecay0_TARGETS_LOADED 1)
 endif()
 
-set(BxDecay0_LIBRARIES BxDecay0)
-### set(BxDecay0_LIBRARIES BxDecay0::BxDecay0)
+set(BxDecay0_LIBRARIES BxDecay0::BxDecay0)
 
 # - end

--- a/examples/ex00/CMakeLists.txt
+++ b/examples/ex00/CMakeLists.txt
@@ -4,4 +4,4 @@ project(bxdecay0_ex00)
 
 find_package(BxDecay0 1.0 REQUIRED CONFIG)
 add_executable (ex00 ex00.cxx)
-target_link_libraries(ex00 BxDecay0)
+target_link_libraries(ex00 BxDecay0::BxDecay0)

--- a/examples/ex01/CMakeLists.txt
+++ b/examples/ex01/CMakeLists.txt
@@ -4,4 +4,4 @@ project(bxdecay0_ex01)
 
 find_package(BxDecay0 1.0 REQUIRED CONFIG)
 add_executable (ex01 ex01.cxx)
-target_link_libraries(ex01 BxDecay0)
+target_link_libraries(ex01 BxDecay0::BxDecay0)

--- a/examples/ex02/CMakeLists.txt
+++ b/examples/ex02/CMakeLists.txt
@@ -7,5 +7,5 @@ find_package(HepMC3 REQUIRED CONFIG)
 
 add_executable(ex02 ex02.cxx)
 target_include_dirs(ex02 ${HEPMC3_INCLUDE_DIRS})
-target_link_libraries(ex02 BxDecay0 ${HEPMC3_LIBRARIES})
+target_link_libraries(ex02 BxDecay0::BxDecay0 ${HEPMC3_LIBRARIES})
 

--- a/examples/ex03/CMakeLists.txt
+++ b/examples/ex03/CMakeLists.txt
@@ -4,4 +4,4 @@ project(bxdecay0_ex03)
 
 find_package(BxDecay0 1.0 REQUIRED CONFIG COMPONENTS manager)
 add_executable (ex03 ex03.cxx)
-target_link_libraries(ex03 BxDecay0)
+target_link_libraries(ex03 BxDecay0::BxDecay0)

--- a/examples/ex04/CMakeLists.txt
+++ b/examples/ex04/CMakeLists.txt
@@ -5,4 +5,4 @@ project(bxdecay0_ex04)
 find_package(BxDecay0 1.0 REQUIRED CONFIG)
 
 add_executable(ex04 ex04.cxx)
-target_link_libraries(ex04 BxDecay0)
+target_link_libraries(ex04 BxDecay0::BxDecay0)

--- a/examples/ex05/CMakeLists.txt
+++ b/examples/ex05/CMakeLists.txt
@@ -4,4 +4,4 @@ project(bxdecay0_ex05)
 
 find_package(BxDecay0 1.0 REQUIRED CONFIG)
 add_executable (ex05 ex05.cxx)
-target_link_libraries(ex05 BxDecay0)
+target_link_libraries(ex05 BxDecay0::BxDecay0)


### PR DESCRIPTION
- Exported BxDecay0 target is correctly namespaced (BxDecay0::BxDecay0)
- CXX Standard is exported via compile feature rather than CMAKE_CXX_STANDARD override, which can break client projects
- A separate variable BxDecay0_CXX_STANDARD is set in the config file to allow client projects to query the built standard if needed
- bxdecay0-config is made fully relocatable without need of the BXDECAY0_PREFIX_PATH environment variable

There's no fix for making the resource lookup relocatable yet, so documentation on BXDECAY0_PREFIX_PATH is left as is.