### PR TITLE
U238 chain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,9 +187,11 @@ set(BxDecay0_HEADERS
   bxdecay0/Pd104low.h
   bxdecay0/Pd106low.h
   bxdecay0/Pd108low.h
+  bxdecay0/Po210.h # Added on the 2020-07-17
   bxdecay0/Po212.h
   bxdecay0/Po214.h
   bxdecay0/Po214low.h
+  bxdecay0/Po218.h # Added on the 2020-07-17
   bxdecay0/Ra222.h
   bxdecay0/Ra222low.h
   bxdecay0/Ra226.h
@@ -217,10 +219,13 @@ set(BxDecay0_HEADERS
   bxdecay0/Te133.h
   bxdecay0/Te133m.h
   bxdecay0/Te134.h
+  bxdecay0/Th230.h # Added on the 2020-07-17
   bxdecay0/Th234.h
   bxdecay0/Ti48low.h
   bxdecay0/Tl207.h
   bxdecay0/Tl208.h
+  bxdecay0/U234.h # Added on the 2020-07-17
+  bxdecay0/U238.h # Added on the 2020-07-17
   bxdecay0/Xe128low.h
   bxdecay0/Xe129m.h
   bxdecay0/Xe130low.h
@@ -367,8 +372,10 @@ set(BxDecay0_SOURCES
   bxdecay0/Pd104low.cc
   bxdecay0/Pd106low.cc
   bxdecay0/Pd108low.cc
+  bxdecay0/Po210.cc  # Added on the 2020-07-17
   bxdecay0/Po212.cc
   bxdecay0/Po214.cc
+  bxdecay0/Po218.cc  # Added on the 2020-07-17
   bxdecay0/Po214low.cc
   bxdecay0/Ra222.cc
   bxdecay0/Ra222low.cc
@@ -397,10 +404,13 @@ set(BxDecay0_SOURCES
   bxdecay0/Te133.cc
   bxdecay0/Te133m.cc
   bxdecay0/Te134.cc
+  bxdecay0/Th230.cc  # Added on the 2020-07-17
   bxdecay0/Th234.cc
   bxdecay0/Ti48low.cc
   bxdecay0/Tl207.cc
   bxdecay0/Tl208.cc
+  bxdecay0/U234.cc  # Added on the 2020-07-17
+  bxdecay0/U238.cc  # Added on the 2020-07-17
   bxdecay0/Xe128low.cc
   bxdecay0/Xe129m.cc
   bxdecay0/Xe130low.cc

--- a/bxdecay0/Po210.cc
+++ b/bxdecay0/Po210.cc
@@ -1,0 +1,92 @@
+// Copyright 1995-2016 V.I. Tretyak
+// Copyright 2020 F. Mauger
+//
+// This program is free software: you  can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free  Software Foundation, either  version 3 of the  License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Ourselves:
+#include <bxdecay0/Po218.h>
+
+// Standard library:
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+// This project:
+#include <bxdecay0/i_random.h>
+#include <bxdecay0/event.h>
+#include <bxdecay0/alpha.h>
+#include <bxdecay0/gamma.h>
+#include <bxdecay0/electron.h>
+#include <bxdecay0/positron.h>
+#include <bxdecay0/particle.h>
+#include <bxdecay0/pair.h>
+#include <bxdecay0/nucltransK.h>
+#include <bxdecay0/nucltransKL.h>
+#include <bxdecay0/nucltransKLM.h>
+#include <bxdecay0/nucltransKLM_Pb.h>
+#include <bxdecay0/beta.h>
+#include <bxdecay0/beta1.h>
+#include <bxdecay0/beta2.h>
+#include <bxdecay0/beta_1fu.h>
+#include <bxdecay0/PbAtShell.h>
+
+namespace bxdecay0 {
+
+  void Po218(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_)
+  {
+    double t;
+    double tdlev;
+    double palpha;
+    double tclev;
+    double thlev;
+    double thnuc;
+    // Model for scheme of Po210 decay (NDS 109, 1527 (2008) and ENSDF at NNDC site
+    // on 17.07.2020).
+    // https://www.nndc.bnl.gov/nudat2/decaysearchdirect.jsp?nuc=210PO&unc=nds
+    // Input : tcnuc_ - time of creation of nucleus (sec)
+    // Output: tdnuc_ - time of decay of nucleus (sec)
+    // // common/genevent/tevst,npfull,npgeant(100),pmoment(3,100),// ptime(100).
+    // VIT, XX.07.2020.
+    thnuc = 138.376 * 24 * 3600.; // sec
+    tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
+    tclev=0.;
+    palpha=100.*prng_();
+    
+    if (palpha <= 0.001)
+      goto label_4516;
+    else 
+      goto label_5306;
+    
+  label_4516:
+    decay0_alpha(prng_, event_, 4.51658,0.,0.,t);
+    thlev=0.;
+    // Simplified model:
+    // - internal electron conversion is null
+    // - pair conversion is null
+    // decay0_nucltransK(prng_, event_, 0.510, 0.093, 0., 0., tclev, thlev, tdlev);
+    decay0_gamma(prng_, event_, 0.8031, tclev, thlev, tdlev);
+    return;
+  label_5306:
+    decay0_alpha(prng_, event_, 5.30433,0.,0.,t);
+    return;
+  }
+
+} // end of namespace bxdecay0
+
+// end of Po218.cc
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/Po210.cc
+++ b/bxdecay0/Po210.cc
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 // Ourselves:
-#include <bxdecay0/Po218.h>
+#include <bxdecay0/Po210.h>
 
 // Standard library:
 #include <sstream>
@@ -42,7 +42,7 @@
 
 namespace bxdecay0 {
 
-  void Po218(i_random & prng_,
+  void Po210(i_random & prng_,
              event & event_,
              const double tcnuc_,
              double & tdnuc_)
@@ -86,7 +86,7 @@ namespace bxdecay0 {
 
 } // end of namespace bxdecay0
 
-// end of Po218.cc
+// end of Po210.cc
 // Local Variables: --
 // mode: c++ --
 // End: --

--- a/bxdecay0/Po210.h
+++ b/bxdecay0/Po210.h
@@ -1,0 +1,20 @@
+#ifndef BXDECAY0_PO210_H
+#define BXDECAY0_PO210_H
+
+namespace bxdecay0 {
+
+  class i_random;
+  class event;
+
+  void Po210(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_);
+
+} // end of namespace bxdecay0
+
+#endif // BXDECAY0_PO210_H
+
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/Po218.cc
+++ b/bxdecay0/Po218.cc
@@ -1,0 +1,93 @@
+// Copyright 1995-2016 V.I. Tretyak
+// Copyright 2020 F. Mauger
+//
+// This program is free software: you  can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free  Software Foundation, either  version 3 of the  License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Ourselves:
+#include <bxdecay0/Po218.h>
+
+// Standard library:
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+// This project:
+#include <bxdecay0/i_random.h>
+#include <bxdecay0/event.h>
+#include <bxdecay0/alpha.h>
+#include <bxdecay0/gamma.h>
+#include <bxdecay0/electron.h>
+#include <bxdecay0/positron.h>
+#include <bxdecay0/particle.h>
+#include <bxdecay0/pair.h>
+#include <bxdecay0/nucltransK.h>
+#include <bxdecay0/nucltransKL.h>
+#include <bxdecay0/nucltransKLM.h>
+#include <bxdecay0/nucltransKLM_Pb.h>
+#include <bxdecay0/beta.h>
+#include <bxdecay0/beta1.h>
+#include <bxdecay0/beta2.h>
+#include <bxdecay0/beta_1fu.h>
+#include <bxdecay0/PbAtShell.h>
+
+namespace bxdecay0 {
+
+  void Po218(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_)
+  {
+    double t;
+    double tdlev;
+    double palpha;
+    double tclev;
+    double thlev;
+    double thnuc;
+    // Model for scheme of Po218 decay (NDS 110, 681 (2009) and ENSDF at NNDC site
+    // on 17.07.2020).
+    // https://www.nndc.bnl.gov/nudat2/decaysearchdirect.jsp?nuc=218PO&unc=nds
+    // Input : tcnuc_ - time of creation of nucleus (sec)
+    // Output: tdnuc_ - time of decay of nucleus (sec)
+    // // common/genevent/tevst,npfull,npgeant(100),pmoment(3,100),// ptime(100).
+    // VIT, XX.07.2020.
+    thnuc = 3.098 * 60.; // sec
+    tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
+    tclev=0.;
+    palpha=100.*prng_();
+    
+    if (palpha <= 0.001){
+      goto label_5181;
+    } else {
+      goto label_6002;
+    }
+    
+  label_5181:
+    decay0_alpha(prng_, event_, 5.181,0.,0.,t);
+    thlev=0.;
+    // Simplified model:
+    // - internal electron conversion is null
+    // - pair conversion is null
+    // decay0_nucltransK(prng_, event_, 0.510, 0.093, 0., 0., tclev, thlev, tdlev);
+    decay0_gamma(prng_, event_, 0.835, tclev, thlev, tdlev);
+    return;
+  label_6002:
+    decay0_alpha(prng_, event_, 6.00235,0.,0.,t);
+    return;
+  }
+
+} // end of namespace bxdecay0
+
+// end of Po218.cc
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/Po218.h
+++ b/bxdecay0/Po218.h
@@ -1,0 +1,20 @@
+#ifndef BXDECAY0_PO218_H
+#define BXDECAY0_PO218_H
+
+namespace bxdecay0 {
+
+  class i_random;
+  class event;
+
+  void Po218(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_);
+
+} // end of namespace bxdecay0
+
+#endif // BXDECAY0_PO218_H
+
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/Th230.cc
+++ b/bxdecay0/Th230.cc
@@ -64,6 +64,7 @@ namespace bxdecay0 {
     tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
     tclev=0.;
     palpha=100.*prng_();
+    double pgamma = 0;
 
     
     if (palpha <= 1.4E-6)
@@ -90,7 +91,7 @@ namespace bxdecay0 {
     decay0_alpha(prng_, event_, 3.8294,0.,0.,t);
   label_873:
     thlev=0.;
-    double pgamma = 100*prng_();
+    pgamma = 100*prng_();
     if (pgamma <= 91) {
       decay0_gamma(prng_, event_, 0.5522, tclev, thlev, tdlev);
       goto label_321;
@@ -111,7 +112,7 @@ namespace bxdecay0 {
     decay0_alpha(prng_, event_, 4.2485,0.,0.,t);
   label_446:
     thlev=0.;
-    double pgamma = 100*prng_();
+    pgamma = 100*prng_();
     if (pgamma <= 3.3) {
       decay0_gamma(prng_, event_, 0.1248, tclev, thlev, tdlev);
       goto label_321;
@@ -132,7 +133,7 @@ namespace bxdecay0 {
     decay0_alpha(prng_, event_, 4.3718,0.,0.,t);
   label_321:
     thlev=0.;
-    double pgamma = 100*prng_();
+    pgamma = 100*prng_();
     if (pgamma <= 10) {
       decay0_gamma(prng_, event_, 0.11, tclev, thlev, tdlev);
       goto label_211;
@@ -146,7 +147,7 @@ namespace bxdecay0 {
     decay0_alpha(prng_, event_, 4.4384,0.,0.,t);
   label_253:
     thlev=0.;
-    double pgamma = 100*prng_();
+    pgamma = 100*prng_();
     if (pgamma <= 73) {
       decay0_gamma(prng_, event_, 0.18605, tclev, thlev, tdlev);
       goto label_67;

--- a/bxdecay0/Th230.cc
+++ b/bxdecay0/Th230.cc
@@ -1,0 +1,182 @@
+// Copyright 1995-2016 V.I. Tretyak
+// Copyright 2020 F. Mauger
+//
+// This program is free software: you  can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free  Software Foundation, either  version 3 of the  License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Ourselves:
+#include <bxdecay0/Th230.h>
+
+// Standard library:
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+// This project:
+#include <bxdecay0/i_random.h>
+#include <bxdecay0/event.h>
+#include <bxdecay0/alpha.h>
+#include <bxdecay0/gamma.h>
+#include <bxdecay0/electron.h>
+#include <bxdecay0/positron.h>
+#include <bxdecay0/particle.h>
+#include <bxdecay0/pair.h>
+#include <bxdecay0/nucltransK.h>
+#include <bxdecay0/nucltransKL.h>
+#include <bxdecay0/nucltransKLM.h>
+#include <bxdecay0/nucltransKLM_Pb.h>
+#include <bxdecay0/beta.h>
+#include <bxdecay0/beta1.h>
+#include <bxdecay0/beta2.h>
+#include <bxdecay0/beta_1fu.h>
+#include <bxdecay0/PbAtShell.h>
+
+namespace bxdecay0 {
+
+  void Th230(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_)
+  {
+    double t;
+    double tdlev;
+    double palpha;
+    double tclev;
+    double thlev;
+    double thnuc;
+    // Model for scheme of Th230 decay (NDS 77, 433 (1996) and ENSDF at NNDC site
+    // on 17.07.2020).
+    // https://www.nndc.bnl.gov/nudat2/decaysearchdirect.jsp?nuc=230TH&unc=nds
+    // Input : tcnuc_ - time of creation of nucleus (sec)
+    // Output: tdnuc_ - time of decay of nucleus (sec)
+    // // common/genevent/tevst,npfull,npgeant(100),pmoment(3,100),// ptime(100).
+    // VIT, XX.07.2020.
+    thnuc = 7.538E4 * 365 * 24 * 3600.; // sec (!)
+    tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
+    tclev=0.;
+    palpha=100.*prng_();
+
+    
+    if (palpha <= 1.4E-6)
+      goto label_3829;
+    else if (palpha <= 4.8E-6)
+      goto label_3877;
+    else if (palpha <= 0.0000151)
+      goto label_4248;
+    else if (palpha <= 0.0000231)
+      goto label_4278;
+    else if (palpha <= 0.0009931)
+      goto label_4371;
+    else if (palpha <= 0.0309931)
+      goto label_4438;
+    else if (palpha <= 0.1509931)
+      goto label_4479;
+    else if (palpha <= 23.5509931)
+      goto label_4620;
+    else
+      goto label_4687;
+
+
+  label_3829:
+    decay0_alpha(prng_, event_, 3.8294,0.,0.,t);
+  label_873:
+    thlev=0.;
+    double pgamma = 100*prng_();
+    if (pgamma <= 91) {
+      decay0_gamma(prng_, event_, 0.5522, tclev, thlev, tdlev);
+      goto label_321;
+    } else {
+      decay0_gamma(prng_, event_, 0.620, tclev, thlev, tdlev);
+      goto label_253;
+    }
+    return;
+
+  label_3877:
+    decay0_alpha(prng_, event_, 3.8778,0.,0.,t);
+  label_824:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.5709, tclev, thlev, tdlev);
+    goto label_253;
+
+  label_4248:
+    decay0_alpha(prng_, event_, 4.2485,0.,0.,t);
+  label_446:
+    thlev=0.;
+    double pgamma = 100*prng_();
+    if (pgamma <= 3.3) {
+      decay0_gamma(prng_, event_, 0.1248, tclev, thlev, tdlev);
+      goto label_321;
+    } else {
+      decay0_gamma(prng_, event_, 0.2348, tclev, thlev, tdlev);
+      goto label_211;
+    }
+    return;
+    
+  label_4278:
+    decay0_alpha(prng_, event_, 4.2783,0.,0.,t);
+  label_416:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.2049, tclev, thlev, tdlev);
+    goto label_211;
+    
+  label_4371:
+    decay0_alpha(prng_, event_, 4.3718,0.,0.,t);
+  label_321:
+    thlev=0.;
+    double pgamma = 100*prng_();
+    if (pgamma <= 10) {
+      decay0_gamma(prng_, event_, 0.11, tclev, thlev, tdlev);
+      goto label_211;
+    } else {
+      decay0_gamma(prng_, event_, 0.2539, tclev, thlev, tdlev);
+      goto label_67;
+    }
+    return;
+    
+  label_4438:
+    decay0_alpha(prng_, event_, 4.4384,0.,0.,t);
+  label_253:
+    thlev=0.;
+    double pgamma = 100*prng_();
+    if (pgamma <= 73) {
+      decay0_gamma(prng_, event_, 0.18605, tclev, thlev, tdlev);
+      goto label_67;
+    } else {
+      decay0_gamma(prng_, event_, 0.25373, tclev, thlev, tdlev);
+      return;
+    }
+
+  label_4479:
+    decay0_alpha(prng_, event_, 4.4798,0.,0.,t);
+  label_211:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.14387, tclev, thlev, tdlev);
+    goto label_67;
+
+  label_4620:
+    decay0_alpha(prng_, event_, 4.46205,0.,0.,t);
+  label_67:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.06767, tclev, thlev, tdlev);
+    return;
+
+  label_4687:
+    decay0_alpha(prng_, event_, 4.46870,0.,0.,t);
+    return;
+  }
+
+} // end of namespace bxdecay0
+
+// end of Th230.cc
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/Th230.h
+++ b/bxdecay0/Th230.h
@@ -1,0 +1,20 @@
+#ifndef BXDECAY0_TH230_H
+#define BXDECAY0_TH230_H
+
+namespace bxdecay0 {
+
+  class i_random;
+  class event;
+
+  void Th230(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_);
+
+} // end of namespace bxdecay0
+
+#endif // BXDECAY0_TH230_H
+
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/U234.cc
+++ b/bxdecay0/U234.cc
@@ -64,7 +64,7 @@ namespace bxdecay0 {
     tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
     tclev=0.;
     palpha=100.*prng_();
-    
+    double pgamma=0;
     if (palpha <= 7E-6)
       goto label_4108;
     else if (palpha <= 3.3E-5)
@@ -87,7 +87,7 @@ namespace bxdecay0 {
     // - pair conversion is null
     // decay0_nucltransK(prng_, evnt_, 0.510, 0.093, 0., 0., tclev, thlev, tdlev);
     
-    double pgamma=100*prng_();
+    pgamma=100*prng_();
     if (pgamma<=86) {
       decay0_gamma(prng_, event_, 0.50355, tclev, thlev, tdlev);
       goto label_174;
@@ -96,7 +96,7 @@ namespace bxdecay0 {
       goto label_53;
     } else {
       decay0_gamma(prng_, event_, 0.67753, tclev, thlev, tdlev);
-      return
+      return;
     }
     return; //in the off chance you get here
     
@@ -110,7 +110,7 @@ namespace bxdecay0 {
     decay0_alpha(prng_, event_, 4.2773,0.,0.,t);
   label_508:
     thlev=0.;
-    double pgamma=100*prng_();
+    pgamma=100*prng_();
     if (pgamma<=40) {
       decay0_gamma(prng_, event_, 0.45492, tclev, thlev, tdlev);
       goto label_53;

--- a/bxdecay0/U234.cc
+++ b/bxdecay0/U234.cc
@@ -1,0 +1,148 @@
+// Copyright 1995-2016 V.I. Tretyak
+// Copyright 2020 F. Mauger
+//
+// This program is free software: you  can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free  Software Foundation, either  version 3 of the  License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Ourselves:
+#include <bxdecay0/U234.h>
+
+// Standard library:
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+// This project:
+#include <bxdecay0/i_random.h>
+#include <bxdecay0/event.h>
+#include <bxdecay0/alpha.h>
+#include <bxdecay0/gamma.h>
+#include <bxdecay0/electron.h>
+#include <bxdecay0/positron.h>
+#include <bxdecay0/particle.h>
+#include <bxdecay0/pair.h>
+#include <bxdecay0/nucltransK.h>
+#include <bxdecay0/nucltransKL.h>
+#include <bxdecay0/nucltransKLM.h>
+#include <bxdecay0/nucltransKLM_Pb.h>
+#include <bxdecay0/beta.h>
+#include <bxdecay0/beta1.h>
+#include <bxdecay0/beta2.h>
+#include <bxdecay0/beta_1fu.h>
+#include <bxdecay0/PbAtShell.h>
+
+namespace bxdecay0 {
+
+  void U234(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_)
+  {
+    double t;
+    double tdlev;
+    double palpha;
+    double tclev;
+    double thlev;
+    double thnuc;
+    // Model for scheme of U234 decay (NDS 108, 681 (2007) and ENSDF at NNDC site
+    // on 17.07.2020).
+    // https://www.nndc.bnl.gov/nudat2/decaysearchdirect.jsp?nuc=238U&unc=nds
+    // Input : tcnuc_ - time of creation of nucleus (sec)
+    // Output: tdnuc_ - time of decay of nucleus (sec)
+    // // common/genevent/tevst,npfull,npgeant(100),pmoment(3,100),// ptime(100).
+    // VIT, XX.07.2020.
+    thnuc = 2.455E5 * 365 * 24 * 3600.; // sec (!)
+    tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
+    tclev=0.;
+    palpha=100.*prng_();
+    
+    if (palpha <= 7E-6)
+      goto label_4108;
+    else if (palpha <= 3.3E-5)
+      goto label_4150;
+    else if (palpha <= 7.3E-5)
+      goto label_4277;
+    else if (palpha <= 0.2)
+      goto label_4603;
+    else if (palpha <= 28.62)
+      goto label_4722;
+    else
+      goto label_4774;
+    
+  label_4108:
+    decay0_alpha(prng_, event_, 4.1086,0.,0.,t);
+  label_677:
+    thlev=0.;
+    // Simplified model:
+    // - internal electron conversion is null
+    // - pair conversion is null
+    // decay0_nucltransK(prng_, evnt_, 0.510, 0.093, 0., 0., tclev, thlev, tdlev);
+    
+    double pgamma=100*prng_();
+    if (pgamma<=86) {
+      decay0_gamma(prng_, event_, 0.50355, tclev, thlev, tdlev);
+      goto label_174;
+    } else if (pgamma<=88) {
+      decay0_gamma(prng_, event_, 0.62433, tclev, thlev, tdlev);
+      goto label_53;
+    } else {
+      decay0_gamma(prng_, event_, 0.67753, tclev, thlev, tdlev);
+      return
+    }
+    return; //in the off chance you get here
+    
+  label_4150:
+    decay0_alpha(prng_, event_, 4.1506,0.,0.,t);
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.58165, tclev, thlev, tdlev);
+    goto label_53;
+
+  label_4277:
+    decay0_alpha(prng_, event_, 4.2773,0.,0.,t);
+  label_508:
+    thlev=0.;
+    double pgamma=100*prng_();
+    if (pgamma<=40) {
+      decay0_gamma(prng_, event_, 0.45492, tclev, thlev, tdlev);
+      goto label_53;
+    } else {
+      decay0_gamma(prng_, event_, 0.50815, tclev, thlev, tdlev);
+      return;
+    }
+    return;
+    
+  label_4603:
+    decay0_alpha(prng_, event_, 4.6035,0.,0.,t);
+  label_174:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.1209, tclev, thlev, tdlev);
+    goto label_53;
+
+
+  label_4722:
+    decay0_alpha(prng_, event_, 4.7224,0.,0.,t);
+  label_53:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.0532, tclev, thlev, tdlev);
+    return;
+    
+  label_4774:
+    decay0_alpha(prng_, event_, 4.7746,0.,0.,t);
+    return;
+  }
+
+} // end of namespace bxdecay0
+
+// end of U234.cc
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/U234.h
+++ b/bxdecay0/U234.h
@@ -1,0 +1,20 @@
+#ifndef BXDECAY0_U234_H
+#define BXDECAY0_U234_H
+
+namespace bxdecay0 {
+
+  class i_random;
+  class event;
+
+  void U234(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_);
+
+} // end of namespace bxdecay0
+
+#endif // BXDECAY0_U234_H
+
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/U238.cc
+++ b/bxdecay0/U238.cc
@@ -1,0 +1,102 @@
+// Copyright 1995-2016 V.I. Tretyak
+// Copyright 2020 F. Mauger
+//
+// This program is free software: you  can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free  Software Foundation, either  version 3 of the  License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Ourselves:
+#include <bxdecay0/U238.h>
+
+// Standard library:
+#include <sstream>
+#include <stdexcept>
+#include <cmath>
+
+// This project:
+#include <bxdecay0/i_random.h>
+#include <bxdecay0/event.h>
+#include <bxdecay0/alpha.h>
+#include <bxdecay0/gamma.h>
+#include <bxdecay0/electron.h>
+#include <bxdecay0/positron.h>
+#include <bxdecay0/particle.h>
+#include <bxdecay0/pair.h>
+#include <bxdecay0/nucltransK.h>
+#include <bxdecay0/nucltransKL.h>
+#include <bxdecay0/nucltransKLM.h>
+#include <bxdecay0/nucltransKLM_Pb.h>
+#include <bxdecay0/beta.h>
+#include <bxdecay0/beta1.h>
+#include <bxdecay0/beta2.h>
+#include <bxdecay0/beta_1fu.h>
+#include <bxdecay0/PbAtShell.h>
+
+namespace bxdecay0 {
+
+  void U238(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_)
+  {
+    double t;
+    double tdlev;
+    double palpha;
+    double tclev;
+    double thlev;
+    double thnuc;
+    // Model for scheme of U238 decay (NDS 108, 681 (2007) and ENSDF at NNDC site
+    // on 17.07.2020).
+    // https://www.nndc.bnl.gov/nudat2/decaysearchdirect.jsp?nuc=238U&unc=nds
+    // Input : tcnuc_ - time of creation of nucleus (sec)
+    // Output: tdnuc_ - time of decay of nucleus (sec)
+    // // common/genevent/tevst,npfull,npgeant(100),pmoment(3,100),// ptime(100).
+    // VIT, XX.07.2020.
+    thnuc = 4.468E9 * 365 * 24 * 3600.; // sec (!)
+    tdnuc_ = tcnuc_-thnuc/std::log(2.)*std::log(prng_());
+    tclev=0.;
+
+    palpha=100.*prng_();
+    if (palpha <= 0.00078)
+      goto label_4038;
+    else if (palpha <= 0.21078)
+      goto label_4151;
+    else
+      goto label_4198;
+    
+  label_4038:
+    decay0_alpha(prng_, event_, 4.038,0.,0.,t);
+    thlev=0.;
+    // Simplified model:
+    // - internal electron conversion is null
+    // - pair conversion is null
+    // decay0_nucltransK(prng_, evnt_, 0.510, 0.093, 0., 0., tclev, thlev, tdlev);
+    decay0_gamma(prng_, event_, 0.1135, tclev, thlev, tdlev);
+    goto label_49; // decay the rest 50keV with another gamma
+    
+  label_4151:
+    decay0_alpha(prng_, event_, 4.151,0.,0.,t);
+  label_49:
+    thlev=0.;
+    decay0_gamma(prng_, event_, 0.04955, tclev, thlev, tdlev);
+    return;
+    
+  label_4198:
+    decay0_alpha(prng_, event_, 4.198,0.,0.,t);
+    return;
+  }
+
+} // end of namespace bxdecay0
+
+// end of U238.cc
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/U238.h
+++ b/bxdecay0/U238.h
@@ -1,0 +1,20 @@
+#ifndef BXDECAY0_U238_H
+#define BXDECAY0_U238_H
+
+namespace bxdecay0 {
+
+  class i_random;
+  class event;
+
+  void U238(i_random & prng_,
+             event & event_,
+             const double tcnuc_,
+             double & tdnuc_);
+
+} // end of namespace bxdecay0
+
+#endif // BXDECAY0_U238_H
+
+// Local Variables: --
+// mode: c++ --
+// End: --

--- a/bxdecay0/genbbsub.cc
+++ b/bxdecay0/genbbsub.cc
@@ -112,9 +112,11 @@
 #include <bxdecay0/Pd104low.h>
 #include <bxdecay0/Pd106low.h>
 #include <bxdecay0/Pd108low.h>
+#include <bxdecay0/Po210.h>
 #include <bxdecay0/Po212.h>
 #include <bxdecay0/Po214.h>
 #include <bxdecay0/Po214low.h>
+#include <bxdecay0/Po218.h>
 #include <bxdecay0/Ra222.h>
 #include <bxdecay0/Ra222low.h>
 #include <bxdecay0/Ra226.h>
@@ -144,11 +146,13 @@
 #include <bxdecay0/Te133.h>
 #include <bxdecay0/Te133m.h>
 #include <bxdecay0/Te134.h>
+#include <bxdecay0/Th230.h>
 #include <bxdecay0/Th234.h>
 #include <bxdecay0/Ti48low.h>
 #include <bxdecay0/Tl207.h>
 #include <bxdecay0/Tl208.h>
-// #include <bxdecay0/U238.h>
+#include <bxdecay0/U234.h>
+#include <bxdecay0/U238.h>
 #include <bxdecay0/Xe128low.h>
 #include <bxdecay0/Xe129m.h>
 #include <bxdecay0/Xe130low.h>
@@ -1312,6 +1316,9 @@ namespace bxdecay0 {
         } else if (name_starts_with(chnuclide_,"Pb211")) {
         } else if (name_starts_with(chnuclide_,"Pb212")) {
         } else if (name_starts_with(chnuclide_,"Pb214")) {
+        } else if (name_starts_with(chnuclide_,"Po210")) {
+        } else if (name_starts_with(chnuclide_,"Po214")) {
+        } else if (name_starts_with(chnuclide_,"Po218")) {
         } else if (name_starts_with(chnuclide_,"Ra226")) {
         } else if (name_starts_with(chnuclide_,"Ra228")) {
         } else if (name_starts_with(chnuclide_,"Rb87")) {
@@ -1326,10 +1333,12 @@ namespace bxdecay0 {
         } else if (name_starts_with(chnuclide_,"Te133m")) {
         } else if (name_starts_with(chnuclide_,"Te133")) {
         } else if (name_starts_with(chnuclide_,"Te134")) {
+        } else if (name_starts_with(chnuclide_,"Th230")) {
         } else if (name_starts_with(chnuclide_,"Th234")) {
         } else if (name_starts_with(chnuclide_,"Tl207")) {
         } else if (name_starts_with(chnuclide_,"Tl208")) {
-        //        } else if (name_starts_with(chnuclide_,"U238")) {
+        } else if (name_starts_with(chnuclide_,"U234")) {
+        } else if (name_starts_with(chnuclide_,"U238")) {
         } else if (name_starts_with(chnuclide_,"Xe129m")) {
         } else if (name_starts_with(chnuclide_,"Xe131m")) {
         } else if (name_starts_with(chnuclide_,"Xe133")) {
@@ -1525,6 +1534,9 @@ namespace bxdecay0 {
       if (name_starts_with(chnuclide_,"Pb211")) Pb211(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Pb212")) Pb212(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Pb214")) Pb214(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"Po210")) Po210(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"Po214")) Po214(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"Po218")) Po218(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Ra226")) Ra226(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Ra228")) Ra228(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Rb87")) Rb87(prng_, event_, 0., tdnuc);
@@ -1540,10 +1552,12 @@ namespace bxdecay0 {
       if (name_starts_with(chnuclide_,"Te133")) Te133(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Te133m")) Te133m(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Te134")) Te134(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"Th230")) Th230(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Th234")) Th234(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Tl207")) Tl207(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Tl208")) Tl208(prng_, event_, 0., tdnuc);
-      // if (name_starts_with(chnuclide_,"U238")) U238(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"U234")) U234(prng_, event_, 0., tdnuc);
+      if (name_starts_with(chnuclide_,"U238")) U238(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Xe129m")) Xe129m(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Xe131m")) Xe131m(prng_, event_, 0., tdnuc);
       if (name_starts_with(chnuclide_,"Xe133")) Xe133(prng_, event_, 0., tdnuc);


### PR DESCRIPTION
Here is the complete U238 chain, following the [advice from François](https://github.com/BxCppDev/bxdecay0/issues/9). I've added the Po214 in `genbbsub`, the source was there but maybe someone forgot to add it in the lists? Obviously it's very simple to remove it if this is deprecated code.

Here is the list of nuclides I've added:
 - Po210
 - Po218
 - Th230
 - U234
 - U238

I've run a job with DUNE simulations where the following are included:
```
   decay_chain:{
      isotope_0:"U238"
      isotope_1:"Th234"
      isotope_2:"Pa234m" // not sure whether it's ok? what does the "m" mean?
      isotope_3:"U234"
      isotope_4:"Th230"
      isotope_5:"Ra226"
      isotope_6:"Rn222"
      isotope_7:"Po218"
      isotope_8:"Pb214"
      isotope_9:"Bi214"
      isotope_10:"Pb210"
      isotope_11:"Bi210"
      isotope_12:"Po210"
   }
```
All worked fine, I can share the output summary file with you (but unfortunately github won't let me upload root files).