### PR TITLE
IN2P3 GitLab instance requires ".git" extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ include_directories("${PROJECT_BINARY_DIR}/bxdecay0")
 set(BxDecay0_SOURCES
   bxdecay0/relocatable_lib.h
   ${PROJECT_BINARY_DIR}/bxdecay0/resource.cc
-  ${PROJECT_BINARY_DIR}/bxdecay0/relocatable_lib.cc 
+  ${PROJECT_BINARY_DIR}/bxdecay0/relocatable_lib.cc
   ${PROJECT_BINARY_DIR}/bxdecay0/BinReloc.h
   bxdecay0/BinReloc.c
   bxdecay0/divdif.cc
@@ -486,7 +486,7 @@ if (BXDECAY0_WITH_DBD_GA)
   endif()
 
   ExternalProject_Add(bxdecay0data_dbd_gA
-    GIT_REPOSITORY "https://gitlab.in2p3.fr/francois.mauger/bxdecay0data"
+    GIT_REPOSITORY "https://gitlab.in2p3.fr/francois.mauger/bxdecay0data.git"
     GIT_TAG        "1.0.1"
     PREFIX         "${CMAKE_BINARY_DIR}/bxdecay0data_dbd_gA"
     # Trick: installing datasets in the BxDecay0 source directory:


### PR DESCRIPTION
Building the latest `develop` with gA enabled results in failure to download the `bxdecay0data` project from the IN2P3 GitLab with 404/22 errors. Simple fix is to explicitly add the `.git` extension to the URL in the `ExternalProject_Add` call.

Tested with CMake 3.17.3, git 1.8.3.1 (CentOS 7 + LCG_98).