### PR TITLE
Add virtual destructor to i_random

### DIFF
--- a/bxdecay0/i_random.h
+++ b/bxdecay0/i_random.h
@@ -29,6 +29,7 @@ namespace bxdecay0 {
   //         uniform deviates distribution in [0;1).
   struct i_random
   {
+    virtual ~i_random() = default;
     virtual double operator()() = 0;
   };
 


### PR DESCRIPTION
For `i_random` to be correctly inheritable and usable as an abstract class, it must have a destructor defined as virtual. This was picked up during the work on Bxcppdev/Bayeux#61, where the code in Bayeux is fine, but emits a warning through inheritance of the non-virtual `i_random`.