### PR TITLE
Improve thread safety of static resources

### DIFF
--- a/bxdecay0/relocatable_lib.cc.in
+++ b/bxdecay0/relocatable_lib.cc.in
@@ -6,6 +6,11 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <mutex>
+#include <thread>
+#include <random>
+#include <chrono>
+
 #include "BinReloc.h"
 
 namespace {
@@ -55,24 +60,27 @@ namespace {
   //   return "@BxDecay0_LIBDIR_TO_PREFIX@";
   // }
 
+  std::string init_libdir()
+  {
+    // Strictly speaking, want a lock_guard here as BinReloc functions aren't threadsafe.
+    // However, as we only call this function to initialize a static variable we should be o.k.
+    // as C++11 should enforce this only being call once over all threads.
+    init_directories();
+    char* exePath = br_find_exe_dir("");
+    std::string libDir(exePath);
+    free(exePath);
+    if (libDir.back() == '/') {
+      libDir = libDir.substr(0, libDir.length() - 1);
+    }
+    return libDir;
+  }
 }
 
 namespace bxdecay0 {
 
   std::string get_library_dir()
   {
-    static std::string libPath;
-    if (libPath.empty()) {
-      init_directories();
-      char* exePath(nullptr);
-      exePath = br_find_exe_dir("");
-      libPath = std::string(exePath);
-      free(exePath);
-      if (libPath.back() == '/') {
-        libPath = libPath.substr(0, libPath.length() - 1);
-      }
-      // std::cerr << "\nbxdecay0: relocatable_lib.cc: get_library_dir: '" << libPath << "'" << std::endl;
-    }
+    static std::string libPath(::init_libdir());
     return libPath;
     // boost::filesystem::path cLibPath = boost::filesystem::canonical(libPath);
     // return cLibPath_path.string();

--- a/bxdecay0/resource.cc.in
+++ b/bxdecay0/resource.cc.in
@@ -37,22 +37,16 @@ namespace {
   }
 
   //! Return the path to the root resource directory
-  std::string get_resource_root(bool overriden_env_) {
-    static std::string _install_resource_root;
-    if (_install_resource_root.empty()) {
-      if (overriden_env_) {
-        const char * env_key = "BXDECAY0_RESOURCE_DIR";
-        if (std::getenv(env_key) != nullptr) {
-          _install_resource_root = std::string(std::getenv(env_key));
-        }
-      }
-      if (_install_resource_root.empty()) {
-        std::string lib_dir = bxdecay0::get_library_dir();
-        // std::cerr << "[devel] lib_dir = " << lib_dir << '\n';
-        _install_resource_root = lib_dir + "/" + relative_lib_path_to_resource_dir();
+  std::string init_resource_root(bool overriden_env_) {
+    if (overriden_env_) {
+      const char * env_key = "BXDECAY0_RESOURCE_DIR";
+      if (std::getenv(env_key) != nullptr) {
+        return std::string(std::getenv(env_key));
       }
     }
-    return _install_resource_root;
+
+    std::string lib_dir = bxdecay0::get_library_dir();
+    return lib_dir + "/" + relative_lib_path_to_resource_dir();
   }
 
 } // namespace
@@ -61,7 +55,8 @@ namespace bxdecay0 {
 
   std::string get_resource_dir(bool overriden_env_)
   {
-    return ::get_resource_root(overriden_env_);
+    static std::string _install_resource_root(::init_resource_root(overriden_env_));
+    return _install_resource_root;
   }
 
   std::string get_resource(const std::string & rname_, bool overriden_env_)
@@ -70,7 +65,7 @@ namespace bxdecay0 {
       throw std::logic_error("Invalid resource name '" + rname_ + "'!");
     }
 
-    std::string fullpath(::get_resource_root(overriden_env_) + "/" + rname_);
+    std::string fullpath(get_resource_dir(overriden_env_) + "/" + rname_);
     std::ifstream check(fullpath.c_str());
     if (!check.good()) {
       throw unreadable_resource_exception("Unreadable resource '" + fullpath + "'!");


### PR DESCRIPTION
As reported in #28, bxdecay0 can produce segfaults when running as the primary generator of a multithreaded Geant4 application. Triaged in this use case to the use of statics in the pattern:

```cpp
const thing_t& function() {
  static thing_t thing;
  if (thing.not_init()) thing.fill();
  ...
  return thing;
}
```

Whilst C++11 guarantees the initialization of `thing` to be thread safe (at least for standard types), the code following that init statement is not. For example, a vector could be initialized then filled if empty, but multiple threads could contend over this filling as some might see it as empty, others not.

The changes in the PR try to solve this through decoupling static initialisation by factoring the filling of the static objects into separate anonymous functions, e.g.

```cpp
namespace {
  thing_t _init_thing() {
    thing_t tmp;
    tmp.fill();
    return tmp;
  }
}

const thing_t& function() {
  static const thing_t thing(::_init_thing());
  return thing;
}
```

As the initialization of the static is only called once, so is the initialization function and thus removing thread contention issues.

Note that the BinReloc functions are not modified using this pattern, but as the calls to these functions are only in `bxdecay0::get_library_dir()` and its init function, these should be sufficiently protected. At worst a `lock_guard` is needed in this one place.

All tests of bxdecay0 pass, and testing in the `remage` use case from #28 largely removes thread safety segfaults. There is one remaining, but this _may_ be due to implementation details of the vertex generation there. 

Also pinging @gipert for info (and optionally testing!).