### PR TITLE
bxdecay0/particle.h: include <cstdint> for uint32_t on GCC 13.

### DIFF
--- a/bxdecay0/particle.h
+++ b/bxdecay0/particle.h
@@ -26,6 +26,7 @@
 // Standard library:
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 // This project:
 #include <bxdecay0/particle_utils.h>


### PR DESCRIPTION
Reference: https://gcc.gnu.org/gcc-13/porting_to.html